### PR TITLE
Refact networks, set depends and refact env

### DIFF
--- a/lesson-6/ubuntu/docker-compose.yml
+++ b/lesson-6/ubuntu/docker-compose.yml
@@ -4,22 +4,36 @@ services:
   db:
     container_name: database
     image: sameersbn/postgresql:10-2
+    environment:
+      POSTGRES_DB: $DB_NAME
+      POSTGRES_PASSWORD: $DB_PASS    
     restart: always
     ports:
       - 5432:5432
-    env_file:
-      - ".env"
-    network_mode: "host"
+    networks:
+      - botnet
+# Uncomment volumes if you need locate db on local host
+#    volumes:
+#      - ./pgdata:/var/lib/postgresql/data
 
   tgbot:
     container_name: bot
     build:
       context: .
-    network_mode: "host"
-
     command: python app.py
+    networks:
+      - botnet
+    ports:
+      - 80:80
     restart: always
-
     env_file:
       - ".env"
+    # bot start after load db
+    depends_on:
+      - db
 
+# указываются используемые сети
+networks:
+  botnet:
+    # указывается драйвер сети
+    driver: bridge

--- a/lesson-6/ubuntu/docker-compose.yml
+++ b/lesson-6/ubuntu/docker-compose.yml
@@ -23,8 +23,6 @@ services:
     command: python app.py
     networks:
       - botnet
-    ports:
-      - 80:80
     restart: always
     env_file:
       - ".env"


### PR DESCRIPTION
1. убираем env_file, так как не за чем импортировать в все переменные из .env включая токе в контейнер postgres
2. при сборке контейнера демон докера подгружает переменные из .env и они доступны в docker-compose, поэтому нужные просто подставляет в enviroments
3. networks - создаём изолированную сеть для контейнеров, так как network_mode: host вещает все на сеть хоста, что нужно только в очень редких случаях. 
4. Если нужно хранить базу на хосте, то нужно раскомментить volumes. Но в папку pgdata можно будет зайти только под рутом. Что бы этот исправить нужно настраивать usernamespace для докера. 
5. пробрасываем порты для постгреса на хост 5432:5432, что бы можно было коннектиться к бд из любого места, а не только с хоста
6. пробрасываем 80 порт для бота, чтобы работал пулинг. Если пулинг использует другой порт, то надо пробросить соответствующий.
7. depends_on: устанавливаем зависимость. Бот запуститься только после загрузки бд.
8. networks: задаем сеть и устанавливаем драйвер
9. При подключение к бд нужно указывать не айпи адрес, а название контейнера host = db (service name)