### PR TITLE
refact db link and rename env params

### DIFF
--- a/lesson-6/ubuntu/database.py
+++ b/lesson-6/ubuntu/database.py
@@ -5,7 +5,7 @@ from sqlalchemy import (Column, Integer, BigInteger, String,
                         Sequence, TIMESTAMP, Boolean, JSON)
 from sqlalchemy import sql
 
-from config import db_pass, db_user, host
+from config import DB_USER, DB_PASS, DB_HOST, DB_NAME
 
 db = Gino()
 
@@ -109,7 +109,7 @@ class DBCommands:
 
 
 async def create_db():
-    await db.set_bind(f'postgresql://{db_user}:{db_pass}@{host}/gino')
+        await db.set_bind(f'postgresql+asyncpg://{DB_USER}:{DB_PASS}@{DB_HOST}/{DB_NAME}')
 
     # Create tables
     db.gino: GinoSchemaVisitor


### PR DESCRIPTION
1. Переименовал переменные из конфига, так как это константы, а их принято в верхнем регистре записывать) Плюс поменял в конфиге и example.env названия так же. Стало более логично и наглядно.
2. Дописал в ссылку коннекта +asyncpg, так как без этого в некоторых случаях, переменные в ссылку будут подставляться некорректно и будет ошибка при коннекте. Звучит странно, но реально есть такая проблема, ни как не могу её объяснить.